### PR TITLE
colorcli for mutt

### DIFF
--- a/colorcli.config
+++ b/colorcli.config
@@ -3,9 +3,9 @@
 # http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
 # https://newsboat.org/releases/<VERSION>/docs/newsboat.html#_configuring_colors
 # color <element> <foreground color> <background color> [<attribute> ...]
-color background          color15   black reverse
+color background          color15   color15
 color listnormal          color59   color15
-color listfocus           white     color31
+color listfocus           color238  color254
 color listnormal_unread   color31   color15  bold
 color listfocus_unread    color31   color254 bold
 color info                color15   color24  bold

--- a/colorcli.config
+++ b/colorcli.config
@@ -3,9 +3,9 @@
 # http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
 # https://newsboat.org/releases/<VERSION>/docs/newsboat.html#_configuring_colors
 # color <element> <foreground color> <background color> [<attribute> ...]
-color background          color15   color15
+color background          color15   black reverse
 color listnormal          color59   color15
-color listfocus           color238  color254
+color listfocus           white     color31
 color listnormal_unread   color31   color15  bold
 color listfocus_unread    color31   color254 bold
 color info                color15   color24  bold

--- a/colorcli.muttrc
+++ b/colorcli.muttrc
@@ -1,0 +1,47 @@
+# COLORS
+# ==================
+# http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
+
+# adapted muttrc colors from https://github.com/webgefrickel/dotfiles
+
+## basic colors ---------------------------------------------------------
+color normal        black           white
+color status        brightwhite     color24
+color indicator     brightcolor24   color250
+color error         color160        white
+color tilde         color31         white
+color markers       red             white
+color attachment    color59         white
+color search        brightmagenta   default
+color tree          color24         white
+
+## sidebar
+color sidebar_new   default         color208
+
+#
+## index ----------------------------------------------------------------
+#
+color index         black           white       "~A"    # all messages
+color index         brightcolor31   white       "~N"    # new messages
+color index         color59         white       "~Q"    # messages that have been replied to
+color index         black           color254    "~P"    # messages from me
+color index         black           color160    "~D"    # deleted messages
+
+#
+## message headers ------------------------------------------------------
+#
+color hdrdefault    black               white
+color header        brightblack         white        "^(From)"
+color header        brightblack         color254     "^(Subject)"
+
+#
+## body -----------------------------------------------------------------
+#
+color quoted        color24             white
+color quoted1       color31             white
+color quoted2       color238            white
+color quoted3       color59             white
+color quoted4       color250            white
+color signature     color59             white
+color bold          brightcolor24       white
+color underline     color24             white

--- a/colorcli.muttrc
+++ b/colorcli.muttrc
@@ -2,29 +2,30 @@
 # ==================
 # http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
 
-# adapted muttrc colors from https://github.com/webgefrickel/dotfiles
+# muttrc.colors structure adapted from https://github.com/webgefrickel/dotfiles
 
 ## basic colors ---------------------------------------------------------
-color normal        black           white
-color status        brightwhite     color24
-color indicator     brightcolor24   color250
-color error         color160        white
-color tilde         color31         white
-color markers       red             white
-color attachment    color59         white
-color search        brightmagenta   default
-color tree          color24         white
+color normal            black           white
+color status            brightwhite     color24
+color indicator         white           color31
+color error             color160        white
+color tilde             color31         white
+color markers           color160        white
+color attachment        color59         white
+color search            white           color31
+color tree              color24         white
 
 ## sidebar
 color sidebar_new       default         color208
-color sidebar_indicator color24         color250
-color sidebar_highlight brightcolor24   color250
+color sidebar_indicator color31         color250
+color sidebar_highlight brightcolor31   color250
 
 #
 ## index ----------------------------------------------------------------
 #
 color index         black           white       "~A"    # all messages
 color index         brightcolor31   white       "~N"    # new messages
+color index         brightcolor24   white       "~O"    # old messages
 color index         color59         white       "~Q"    # messages that have been replied to
 color index         black           color254    "~P"    # messages from me
 color index         black           color160    "~D"    # deleted messages

--- a/colorcli.muttrc
+++ b/colorcli.muttrc
@@ -16,7 +16,9 @@ color search        brightmagenta   default
 color tree          color24         white
 
 ## sidebar
-color sidebar_new   default         color208
+color sidebar_new       default         color208
+color sidebar_indicator color24         color250
+color sidebar_highlight brightcolor24   color250
 
 #
 ## index ----------------------------------------------------------------


### PR DESCRIPTION
# Thank you for your contribution!

## What did you change?

File for mutt added. Doesn't use ``default`` color but sets white background explicitly. This has been done so it works also in dark terminals.

## How can others test the changes?

source the colorcli.muttrc in your muttrc.

## SUBMITTER - PR-Checklist

Please uncheck - if not applicable - the boxes in this list AFTER submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I have tested **all** changes included in this PR.
- [x] I have also reviewed this pull request myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I have merged the `master` branch into my branch before finishing this pull request.
- [x] I have **not added any other changes** than the ones described above.
- [x] I have mentioned all **pull requests, which relate to this one**
