### PR TITLE
Fix cmus transparency

### DIFF
--- a/colorcli.config
+++ b/colorcli.config
@@ -3,9 +3,9 @@
 # http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
 # https://newsboat.org/releases/<VERSION>/docs/newsboat.html#_configuring_colors
 # color <element> <foreground color> <background color> [<attribute> ...]
-color background          color15   color15
+color background          color15   black reverse
 color listnormal          color59   color15
-color listfocus           color238  color254
+color listfocus           white     color31
 color listnormal_unread   color31   color15  bold
 color listfocus_unread    color31   color254 bold
 color info                color15   color24  bold

--- a/colorcli.muttrc
+++ b/colorcli.muttrc
@@ -1,0 +1,47 @@
+# COLORS
+# ==================
+# http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
+
+# adapted muttrc colors from https://github.com/webgefrickel/dotfiles
+
+## basic colors ---------------------------------------------------------
+color normal        black           white
+color status        brightwhite     color24
+color indicator     brightcolor24   color250
+color error         color160        white
+color tilde         color31         white
+color markers       red             white
+color attachment    color59         white
+color search        brightmagenta   default
+color tree          color24         white
+
+## sidebar
+color sidebar_new   default         color208
+
+#
+## index ----------------------------------------------------------------
+#
+color index         black           white       "~A"    # all messages
+color index         brightcolor31   white       "~N"    # new messages
+color index         color59         white       "~Q"    # messages that have been replied to
+color index         black           color254    "~P"    # messages from me
+color index         black           color160    "~D"    # deleted messages
+
+#
+## message headers ------------------------------------------------------
+#
+color hdrdefault    black               white
+color header        brightblack         white        "^(From)"
+color header        brightblack         color254     "^(Subject)"
+
+#
+## body -----------------------------------------------------------------
+#
+color quoted        color24             white
+color quoted1       color31             white
+color quoted2       color238            white
+color quoted3       color59             white
+color quoted4       color250            white
+color signature     color59             white
+color bold          brightcolor24       white
+color underline     color24             white

--- a/colorcli.muttrc
+++ b/colorcli.muttrc
@@ -2,29 +2,30 @@
 # ==================
 # http://www.newsbeuter.org/doc/newsbeuter.html#_configuring_colors
 
-# adapted muttrc colors from https://github.com/webgefrickel/dotfiles
+# muttrc.colors structure adapted from https://github.com/webgefrickel/dotfiles
 
 ## basic colors ---------------------------------------------------------
-color normal        black           white
-color status        brightwhite     color24
-color indicator     brightcolor24   color250
-color error         color160        white
-color tilde         color31         white
-color markers       red             white
-color attachment    color59         white
-color search        brightmagenta   default
-color tree          color24         white
+color normal            black           white
+color status            brightwhite     color24
+color indicator         white           color31
+color error             color160        white
+color tilde             color31         white
+color markers           color160        white
+color attachment        color59         white
+color search            white           color31
+color tree              color24         white
 
 ## sidebar
 color sidebar_new       default         color208
-color sidebar_indicator color24         color250
-color sidebar_highlight brightcolor24   color250
+color sidebar_indicator color31         color250
+color sidebar_highlight brightcolor31   color250
 
 #
 ## index ----------------------------------------------------------------
 #
 color index         black           white       "~A"    # all messages
 color index         brightcolor31   white       "~N"    # new messages
+color index         brightcolor24   white       "~O"    # old messages
 color index         color59         white       "~Q"    # messages that have been replied to
 color index         black           color254    "~P"    # messages from me
 color index         black           color160    "~D"    # deleted messages

--- a/colorcli.muttrc
+++ b/colorcli.muttrc
@@ -16,7 +16,9 @@ color search        brightmagenta   default
 color tree          color24         white
 
 ## sidebar
-color sidebar_new   default         color208
+color sidebar_new       default         color208
+color sidebar_indicator color24         color250
+color sidebar_highlight brightcolor24   color250
 
 #
 ## index ----------------------------------------------------------------

--- a/colorcli.theme
+++ b/colorcli.theme
@@ -26,15 +26,16 @@
 #
 # BASICS
 #
+
 # BASICS: TEXT COLOR
 set color_win_fg=59
 
 # BASICS: BACKGROUND COLOR
-set color_win_bg=default
+set color_win_bg=white
 
 # BASICS: COMMAND LINE
-set color_cmdline_bg=default
-set color_cmdline_fg=default
+set color_cmdline_bg=254
+set color_cmdline_fg=black
 set color_error=160
 set color_info=24
 set color_separator=254
@@ -59,11 +60,11 @@ set color_win_title_fg=15
 set color_win_cur=31
 
 # PLAYING: ACTIVE SELECTION
-set color_win_cur_sel_bg=254
+set color_win_cur_sel_bg=250
 set color_win_cur_sel_fg=24
 
 # PLAYING: INACTIVE SELECTION
-set color_win_inactive_cur_sel_bg=254
+set color_win_inactive_cur_sel_bg=250
 set color_win_inactive_cur_sel_fg=24
 
 #==============================================================================
@@ -71,11 +72,11 @@ set color_win_inactive_cur_sel_fg=24
 # COLLECTION
 #
 # COLLECTION: ACTIVE SELECTION
-set color_win_sel_bg=254
+set color_win_sel_bg=250
 set color_win_sel_fg=238
 
 # COLLECTION: INACTIVE SELECTION
-set color_win_inactive_sel_bg=default
+set color_win_inactive_sel_bg=white
 set color_win_inactive_sel_fg=31
 
 #==============================================================================
@@ -83,4 +84,11 @@ set color_win_inactive_sel_fg=31
 # DIRECTORIES
 #
 # DIRECTORIES: DIRECTORY LISTING
-set color_win_dir=59
+set color_win_dir=31
+
+# Album row in the track window
+#
+# Fix transparency/dark issues 
+set color_trackwin_album_bg=white
+set color_trackwin_album_fg=black
+


### PR DESCRIPTION
# Thank you for your contribution!

## What did you change?

I use default gnome terminal on Ubuntu, which is transparent. Background colors using the `default` setting will be than transparent, and not white, as required for colorcli to look good.  Here is the fix

## How can others test the changes?

> Describe how others can test the changes introduced by this pull request. Please remove this section if changes can not be tested.

## SUBMITTER - PR-Checklist

Please uncheck - if not applicable - the boxes in this list AFTER submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I have tested **all** changes included in this PR.
- [x] I have also reviewed this pull request myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I have merged the `master` branch into my branch before finishing this pull request.
- [x] I have **not added any other changes** than the ones described above.
- [x] I have mentioned all **pull requests, which relate to this one**
